### PR TITLE
Fix link in 2024-03-08-Episode-172.md

### DIFF
--- a/_posts/2024-03-08-Episode-172.md
+++ b/_posts/2024-03-08-Episode-172.md
@@ -44,7 +44,7 @@ excerpt_separator: <!--more-->
 * [NVIDIA/`stdexec` - Senders - A Standard Model for Asynchronous Execution in C++](https://github.com/NVIDIA/stdexec)
 * [Circle C++ Compiler](https://www.circle-lang.org/)
 * [CppFront](https://github.com/hsutter/cppfront)
-* [Meta programmable functional notebooks with Livebook by José Valim | Lambda Days 2023](https://youtu.be/5Zt5TNqKhcA?si=4Ul4pFsQAwd9Ut1u&t=1875)
+* [Meta programmable functional notebooks with Livebook by José Valim \| Lambda Days 2023](https://youtu.be/5Zt5TNqKhcA?si=4Ul4pFsQAwd9Ut1u&t=1875)
 
 ### Intro Song Info
  


### PR DESCRIPTION
Fix Livebook link by escaping `|`

Currently, it looks like this ⬇️. My guess is it's due to not escaping the `|`.

![broken_link](https://github.com/codereport/adsp2/assets/120668309/5ef352f8-0340-435b-8a61-d63865c50e7c)
