### PR TITLE
fix: Correct link for C++ Forward Progress documentation

### DIFF
--- a/_posts/2024-03-01-Episode-171.md
+++ b/_posts/2024-03-01-Episode-171.md
@@ -29,7 +29,7 @@ excerpt_separator: <!--more-->
 * [CUB Library](https://nvidia.github.io/cccl/cub/)
 * [Single-pass Parallel Prefix Scan with Decoupled Look-back](https://research.nvidia.com/sites/default/files/pubs/2016-03_Single-pass-Parallel-Prefix/nvr-2016-002.pdf)
 * [Forward Progress in C++ - Olivier Giroux - CppNorth 2022](https://www.youtube.com/watch?v=CuWM-OrPitw)
-* [C++ Forward Progress](https://en.cppreference.com/w/cpp/language/memory_model#:~:text=Forward%20progress,-Obstruction%20freedom&text=When%20only%20one%20thread%20that,operations%20are%20obstruction%2Dfree)
+* [C++ Forward Progress](https://en.cppreference.com/w/cpp/language/multithread#Forward_progress)
 * [ADSP Episode 25: The Lost Reduction](https://adspthepodcast.com/2021/05/14/Episode-25.html)
 * [GitHub CCCL Issue #774: Add non-commutative reduction](https://github.com/NVIDIA/cccl/issues/774)
 * [ACCU Conference](https://accuconference.org/)


### PR DESCRIPTION
cppreference.com has been updated since the show, and the Forward Progress content moved to another page.