### PR TITLE
Link fixes for 2024-03-08-Episode-172.md

### DIFF
--- a/_posts/2024-03-08-Episode-172.md
+++ b/_posts/2024-03-08-Episode-172.md
@@ -40,7 +40,7 @@ excerpt_separator: <!--more-->
 * [NYC++: March 2024 at Adobe ft., Sean Parent](https://www.meetup.com/new-york-c-c-meetup-group/events/299348651/)
 * Sean Parent's Chains Talk
 * [Sean Parent's `chains` Library](https://github.com/stlab/chains)
-* [C++ Senders and Receivers](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2020/p0443r14.html)
+* [C++ Senders and Receivers](https://wg21.link/p2300)
 * [NVIDIA/`stdexec` - Senders - A Standard Model for Asynchronous Execution in C++](https://github.com/NVIDIA/stdexec)
 * [Circle C++ Compiler](https://www.circle-lang.org/)
 * [CppFront](https://github.com/hsutter/cppfront)

--- a/_posts/2024-03-08-Episode-172.md
+++ b/_posts/2024-03-08-Episode-172.md
@@ -44,7 +44,7 @@ excerpt_separator: <!--more-->
 * [NVIDIA/`stdexec` - Senders - A Standard Model for Asynchronous Execution in C++](https://github.com/NVIDIA/stdexec)
 * [Circle C++ Compiler](https://www.circle-lang.org/)
 * [CppFront](https://github.com/hsutter/cppfront)
-* [Meta programmable functional notebooks with Livebook by José Valim \| Lambda Days 2023](https://youtu.be/5Zt5TNqKhcA?si=4Ul4pFsQAwd9Ut1u&t=1875)
+* [Meta programmable functional notebooks with Livebook by José Valim \| Lambda Days 2023](https://youtu.be/5Zt5TNqKhcA?t=1875)
 
 ### Intro Song Info
  


### PR DESCRIPTION
- p2300 has superseded p0443 as the S&R paper, so readers should read that paper instead
- Remove tracker from Livebook talk link